### PR TITLE
Removes support for XS3_MATH_VECTOR_TAIL_SUPPORT.

### DIFF
--- a/lib_xs3_math/api/xs3_math_conf.h
+++ b/lib_xs3_math/api/xs3_math_conf.h
@@ -32,55 +32,6 @@
 #endif
 
 
-/**
- * @page compile_time_options Compile Time Options
- * 
- * @par Disable Vector Tail Support
- * 
- *     XS3_MATH_VECTOR_TAIL_SUPPORT
- * 
- * Most of the `lib_xs3_math` API functions take vectors as inputs or outputs. By default there are no restrictions on 
- * the lengths of these vectors (other than being non-zero).
- * 
- * The XS3 vector registers are `256` bits. Optimal performance is obtained when the length of a vector is a multiple of 
- * the vector register length. The table below indicates the bit depth (bits-per-element; BPE) and number of 
- * elements-per-vector (EPV) for frequently-used data types. Vector elements in excess of a natural boundary (i.e. 
- * `vector_length mod EPV`) are often referred to in this library as the "tail" of a vector.
- * 
- * Usually checking for vector tails does not cost more than a few thread cycles per API function call when there is no 
- * tail. Where there is a tail, handling the tail within an API function is often significantly more expensive than 
- * dealing with a full EPV elements. It is, for example, considerably faster to multiply two 16-bit vectors of length 
- * `16` (using the VPU) than two vectors of length `1`.
- * 
- * The main drawback of allowing vector tails is that it entails a sometimes significant increase in the code memory 
- * footprint. To that end, where an application can guarantee that all vector lengths are an integer multiple of EPV for 
- * that element type, support for vectors tails in some API functions can be disabled by compiling with the macro 
- * `XS3_MATH_VECTOR_TAIL_SUPPORT` defined to be zero.
- * 
- * If vector tail support is disabled, the behavior of API functions where tails are implied by vector lengths is 
- * undefined.
- * 
- * @note Currently, most functions do not yet respect this option.
- * 
- * Element Type  | BPE | EPV 
- * ------------- | --- | ---
- * int8_t        |  8  | 32
- * int16_t       | 16  | 16
- * int32_t       | 32  |  8
- * complex_s32_t | 64  |  4
- * 
- * By default, tails are supported (1).
- * 
- */
- #ifndef XS3_MATH_VECTOR_TAIL_SUPPORT
-
-/**
- * See @ref compile_time_options for details.
- */
- #define XS3_MATH_VECTOR_TAIL_SUPPORT (1)
- #endif
-
-
 
 /**
  * @page compile_time_options Compile Time Options

--- a/lib_xs3_math/src/arch/xcore/xs3_vect_abs.S
+++ b/lib_xs3_math/src/arch/xcore/xs3_vect_abs.S
@@ -10,17 +10,8 @@
 .issue_mode dual
 .align 4
 
-#if XS3_MATH_VECTOR_TAIL_SUPPORT
-  #define NSTACKWORDS     (8)
-#else
-  #define NSTACKWORDS     (0)
-#endif
-
-#if XS3_MATH_VECTOR_TAIL_SUPPORT
-  #define STACK_TMP_VEC       (NSTACKWORDS-8)
-#endif
-
-
+#define NSTACKWORDS     (8)
+#define STACK_TMP_VEC       (NSTACKWORDS-8)
 
 #define a           r0
 #define b           r1
@@ -40,14 +31,9 @@ headroom_t xs3_vect_s16_abs(
 xs3_vect_s16_abs:
         dualentsp NSTACKWORDS
         ldc r11, 0x0100
-#if XS3_MATH_VECTOR_TAIL_SUPPORT
     {   shl tail, len, SIZEOF_LOG2_S16          ;   shr len, len, EPV_LOG2_S16              }
     {   zext tail, 5                            ;   vsetc r11                               }
     {                                           ;   bu .L_apply_op                          }
-#else //XS3_MATH_VECTOR_TAIL_SUPPORT
-    {   shr len, len, EPV_LOG2_S16              ;   vsetc r11                               }
-    {                                           ;   bu .L_apply_op                          }
-#endif //XS3_MATH_VECTOR_TAIL_SUPPORT
 
 .L_func_end_s16:
 .cc_bottom xs3_vect_s16_abs.function
@@ -63,16 +49,10 @@ headroom_t xs3_vect_s32_abs(
 .cc_top xs3_vect_s32_abs.function,xs3_vect_s32_abs
 
 xs3_vect_s32_abs:
-#if XS3_MATH_VECTOR_TAIL_SUPPORT
         dualentsp NSTACKWORDS
     {   ldc r11, 0                              ;   shl tail, len, SIZEOF_LOG2_S32          }
     {   shr len, len, EPV_LOG2_S32              ;   vsetc r11                               }
     {   zext tail, 5                            ;   bu .L_apply_op                          }
-#else //XS3_MATH_VECTOR_TAIL_SUPPORT
-    {   ldc r11, 0                              ;   dualentsp NSTACKWORDS                   }
-    {   shr len, len, EPV_LOG2_S32              ;   vsetc r11                               }
-    {                                           ;   bu .L_apply_op                          }
-#endif //XS3_MATH_VECTOR_TAIL_SUPPORT
 
 .L_func_end_s32:
 .cc_bottom xs3_vect_s32_abs.function
@@ -103,9 +83,7 @@ xs3_vect_s32_abs:
 
 .L_apply_op:
 
-#if XS3_MATH_VECTOR_TAIL_SUPPORT
     {   mkmsk tail, tail                        ;                                           }
-#endif //XS3_MATH_VECTOR_TAIL_SUPPORT
     {   mov r11, b                              ;   bf loop_count, .L_loop_bot              }
     {   ldc r1, 32                              ;   bu .L_loop_top                          }
 .align 16
@@ -116,8 +94,6 @@ xs3_vect_s32_abs:
         {   add a, a, r1                            ;   vstr a[0]                               }
         {   add r11, r11, r1                        ;   bt loop_count, .L_loop_top              }
 .L_loop_bot:
-
-#if XS3_MATH_VECTOR_TAIL_SUPPORT
 
     {                                           ;   bf tail, .L_finish                      }
     {                                           ;   vclrdr                                  }
@@ -130,8 +106,6 @@ xs3_vect_s32_abs:
     {                                           ;   vldr r11[0]                             }
     {                                           ;   vstr r11[0]                             }
         vstrpv a[0], tail
-
-#endif //XS3_MATH_VECTOR_TAIL_SUPPORT
 
 .L_finish:
     {   ldc r0, 32                              ;   vgetc r11                               }

--- a/lib_xs3_math/src/arch/xcore/xs3_vect_rect.S
+++ b/lib_xs3_math/src/arch/xcore/xs3_vect_rect.S
@@ -11,24 +11,14 @@
 .issue_mode dual
 .align 4
 
-#if XS3_MATH_VECTOR_TAIL_SUPPORT
-  #define NSTACKWORDS     (8)
-#else
-  #define NSTACKWORDS     (0)
-#endif
+#define NSTACKWORDS     (8)
 
-
-#if XS3_MATH_VECTOR_TAIL_SUPPORT
-  #define STACK_TMP_VEC       (NSTACKWORDS-8)
-#endif
+#define STACK_TMP_VEC       (NSTACKWORDS-8)
 
 #define a           r0
 #define b           r1
 #define len         r2
 #define tail        r3
-
-
-
 
 
 
@@ -44,15 +34,9 @@ headroom_t xs3_vect_s16_rect(
 xs3_vect_s16_rect:
         dualentsp NSTACKWORDS
         ldc r11, 0x0100
-
-#if XS3_MATH_VECTOR_TAIL_SUPPORT
     {   shl tail, len, SIZEOF_LOG2_S16          ;   shr len, len, EPV_LOG2_S16              }
     {   zext tail, 5                            ;   vsetc r11                               }
     {                                           ;   bu .L_apply_op                          }
-#else //XS3_MATH_VECTOR_TAIL_SUPPORT
-    {   shr len, len, EPV_LOG2_S16              ;   vsetc r11                               }
-    {                                           ;   bu .L_apply_op                          }
-#endif //XS3_MATH_VECTOR_TAIL_SUPPORT
 
 .L_func_end_s16:
 .cc_bottom xs3_vect_s16_rect.function
@@ -70,16 +54,10 @@ headroom_t xs3_vect_s32_rect(
 .cc_top xs3_vect_s32_rect.function,xs3_vect_s32_rect
 
 xs3_vect_s32_rect:
-#if XS3_MATH_VECTOR_TAIL_SUPPORT
         dualentsp NSTACKWORDS
     {   ldc r11, 0                              ;   shl tail, len, SIZEOF_LOG2_S32          }
     {   shr len, len, EPV_LOG2_S32              ;   vsetc r11                               }
     {   zext tail, 5                            ;   bu .L_apply_op                          }
-#else //XS3_MATH_VECTOR_TAIL_SUPPORT
-    {   ldc r11, 0                              ;   dualentsp NSTACKWORDS                   }
-    {   shr len, len, EPV_LOG2_S32              ;   vsetc r11                               }
-    {                                           ;   bu .L_apply_op                          }
-#endif //XS3_MATH_VECTOR_TAIL_SUPPORT
 
 .L_func_end_s32:
 .cc_bottom xs3_vect_s32_rect.function
@@ -110,9 +88,7 @@ xs3_vect_s32_rect:
 
 .L_apply_op:
 
-#if XS3_MATH_VECTOR_TAIL_SUPPORT
     {   mkmsk tail, tail                        ;                                           }
-#endif //XS3_MATH_VECTOR_TAIL_SUPPORT
     {   mov r11, b                              ;   bf loop_count, .L_loop_bot              }
     {   ldc r1, 32                              ;   bu .L_loop_top                          }
 .align 16
@@ -123,8 +99,6 @@ xs3_vect_s32_rect:
         {                                           ;   bt loop_count, .L_loop_top              }
 .L_loop_bot:
 
-#if XS3_MATH_VECTOR_TAIL_SUPPORT
-
     {                                           ;   bf tail, .L_finish                      }
     {                                           ;   vclrdr                                  }
     {   ldaw r11, sp[STACK_TMP_VEC]             ;   vldr r11[0]                             }
@@ -134,8 +108,6 @@ xs3_vect_s32_rect:
     {                                           ;   vldr r11[0]                             }
     {                                           ;   vstr r11[0]                             }
         vstrpv a[0], tail
-
-#endif //XS3_MATH_VECTOR_TAIL_SUPPORT
 
 .L_finish:
     {   ldc r0, 32                              ;   vgetc r11                               }

--- a/lib_xs3_math/src/arch/xcore/xs3_vect_s16_to_s32.S
+++ b/lib_xs3_math/src/arch/xcore/xs3_vect_s16_to_s32.S
@@ -17,11 +17,7 @@ headroom_t xs3_vect_s16_to_s32(
 .issue_mode dual
 .align 4
 
-#if XS3_MATH_VECTOR_TAIL_SUPPORT
-  #define NSTACKWORDS     (2)
-#else
-  #define NSTACKWORDS     (0)
-#endif
+#define NSTACKWORDS     (2)
 
 #define FUNCTION_NAME   xs3_vect_s16_to_s32
 
@@ -40,15 +36,11 @@ FUNCTION_NAME:
         ldc r11, 0x0200
     {   ldap r11, .L_vlmacc_consts_A            ;   vsetc r11                               }
 
-#if XS3_MATH_VECTOR_TAIL_SUPPORT
         std r4, r5, sp[0]
     {   shl tail, len, SIZEOF_LOG2_S32          ;                                           }
     {   shr len, len, EPV_LOG2_S32              ;   zext tail, 5                            }
     {   mkmsk tail, tail                        ;   bf len, .L_loop_bot                     }
     {                                           ;   bu .L_loop_top                          }
-#else // XS3_MATH_VECTOR_TAIL_SUPPORT
-    {   shr len, len, EPV_LOG2_S32              ;   bu .L_loop_top                          }
-#endif // XS3_MATH_VECTOR_TAIL_SUPPORT
 
 .align 16
 
@@ -88,7 +80,6 @@ FUNCTION_NAME:
         {   add a, a, _16                           ;   bt len, .L_loop_top                     }
 .L_loop_bot:
 
-#if XS3_MATH_VECTOR_TAIL_SUPPORT
     {   ldc _16, 16                             ;   bf tail, .L_finish                      }
     {                                           ;   vclrdr                                  }
     {                                           ;   vldc b[0]                               }
@@ -96,7 +87,6 @@ FUNCTION_NAME:
     {   add r11, r11, _16                       ;   vlmacc r11[0]                           }
     {                                           ;   vlmacc r11[0]                           }
     vstrpv a[0], tail
-#endif // XS3_MATH_VECTOR_TAIL_SUPPORT
 
 .L_finish:
         ldd r4, r5, sp[0]

--- a/lib_xs3_math/src/arch/xcore/xs3_vect_s32_to_s16.S
+++ b/lib_xs3_math/src/arch/xcore/xs3_vect_s32_to_s16.S
@@ -41,10 +41,8 @@ FUNCTION_NAME:
     {   ldc r11, 0                              ;   ldc _16, 16                         }
     {   sub b_shr, b_shr, _16                   ;   vsetc r11                           }
     {   shr len, len, EPV_LOG2_S32              ;   shl tail, len, SIZEOF_LOG2_S16      }
-#if XS3_MATH_VECTOR_TAIL_SUPPORT
     {                                           ;   zext tail, 4                        }
     {   mkmsk tail, tail                        ;   bf len, .L_loop_bot                 }
-#endif //XS3_MATH_VECTOR_TAIL_SUPPORT
     {   mkmsk r11, 16                           ;   bu .L_loop_top                      }
 
 .align 16
@@ -56,13 +54,11 @@ FUNCTION_NAME:
     {   add a, a, _16                           ;   bt len, .L_loop_top                 }
 .L_loop_bot:
 
-#if XS3_MATH_VECTOR_TAIL_SUPPORT
     {                                           ;   bf tail, .L_finish                  }
     {                                           ;   vclrdr                              }
         vlashr b[0], b_shr
     {                                           ;   vdepth16                            }
         vstrpv a[0], tail
-#endif //XS3_MATH_VECTOR_TAIL_SUPPORT
 
 .L_finish:
         ldd r4, r5, sp[0]

--- a/test/bfp_tests/CMakeLists.txt
+++ b/test/bfp_tests/CMakeLists.txt
@@ -13,7 +13,8 @@ list( APPEND  DEP_LIBS_Linux  m   )
 file( GLOB_RECURSE SOURCES_C  src/*.c )
 file( GLOB_RECURSE SOURCES_XC src/*.xc )
 
-set( XSCOPE_CONFIG config.xscope )
+# set( XSCOPE_CONFIG config.xscope )
+get_filename_component(XSCOPE_CONFIG config.xscope ABSOLUTE)
 
 ## Compile flags
 unset(COMPILE_FLAGS)
@@ -32,16 +33,16 @@ list( APPEND  LINKER_FLAGS  "" )
 unset(LINKER_FLAGS_XCORE)
 list( APPEND  LINKER_FLAGS_XCORE  -target=${XCORE_TARGET} )
 list( APPEND  LINKER_FLAGS_XCORE  -report                 )
+list( APPEND  LINKER_FLAGS_XCORE  ${XSCOPE_CONFIG}        )
 
 unset(LINKER_FLAGS_Linux)
 list( APPEND  LINKER_FLAGS_Linux  ""                      )
-
+ 
 
 #########
 
 list( APPEND  SOURCES         ${SOURCES_C}     )
 list( APPEND  SOURCES_XCORE   ${SOURCES_XC}    )
-list( APPEND  SOURCES_XCORE   ${XSCOPE_CONFIG} )
 list( APPEND  SOURCES   ${SOURCES_${CMAKE_SYSTEM_NAME}} )
 
 list( APPEND  COMPILE_FLAGS ${COMPILE_FLAGS_${CMAKE_SYSTEM_NAME}} )

--- a/test/fft_tests/CMakeLists.txt
+++ b/test/fft_tests/CMakeLists.txt
@@ -13,7 +13,8 @@ list( APPEND  DEP_LIBS_Linux  m   )
 file( GLOB_RECURSE SOURCES_C  src/*.c )
 file( GLOB_RECURSE SOURCES_XC src/*.xc )
 
-set( XSCOPE_CONFIG config.xscope )
+# set( XSCOPE_CONFIG config.xscope )
+get_filename_component(XSCOPE_CONFIG config.xscope ABSOLUTE)
 
 ## Compile flags
 unset(COMPILE_FLAGS)
@@ -32,6 +33,7 @@ list( APPEND  LINKER_FLAGS  "" )
 unset(LINKER_FLAGS_XCORE)
 list( APPEND  LINKER_FLAGS_XCORE  -target=${XCORE_TARGET} )
 list( APPEND  LINKER_FLAGS_XCORE  -report                 )
+list( APPEND  LINKER_FLAGS_XCORE  ${XSCOPE_CONFIG}        )
 
 unset(LINKER_FLAGS_Linux)
 list( APPEND  LINKER_FLAGS_Linux  ""                      )
@@ -41,7 +43,6 @@ list( APPEND  LINKER_FLAGS_Linux  ""                      )
 
 list( APPEND  SOURCES         ${SOURCES_C}     )
 list( APPEND  SOURCES_XCORE   ${SOURCES_XC}    )
-list( APPEND  SOURCES_XCORE   ${XSCOPE_CONFIG} )
 list( APPEND  SOURCES   ${SOURCES_${CMAKE_SYSTEM_NAME}} )
 
 list( APPEND  COMPILE_FLAGS ${COMPILE_FLAGS_${CMAKE_SYSTEM_NAME}} )

--- a/test/fft_tests/config.xscope
+++ b/test/fft_tests/config.xscope
@@ -14,7 +14,7 @@
 <!--   "NONE", "UINT", "INT", "FLOAT"                        -->
 <!-- ======================================================= -->
 
-<xSCOPEconfig ioMode="none" enabled="false">
+<xSCOPEconfig ioMode="basic" enabled="true">
 
     <!-- For example: -->
     <!-- <Probe name="Probe Name" type="CONTINUOUS" datatype="UINT" units="Value" enabled="true"/> -->

--- a/test/fft_tests/src/test_xs3_fft_mono_adjust.c
+++ b/test/fft_tests/src/test_xs3_fft_mono_adjust.c
@@ -103,7 +103,7 @@ void test_xs3_fft_mono_adjust_forward()
             TEST_ASSERT_CONVERSION(error);
 
             if(diff > worst_error) { worst_error = diff; }
-            TEST_ASSERT_LESS_OR_EQUAL_UINT32_MESSAGE(k+3, diff, "Output delta is too large");
+            TEST_ASSERT_LESS_OR_EQUAL_UINT32_MESSAGE(k+4, diff, "Output delta is too large");
         }
         
 #if PRINT_ERRORS

--- a/test/vect_tests/CMakeLists.txt
+++ b/test/vect_tests/CMakeLists.txt
@@ -13,7 +13,8 @@ list( APPEND  DEP_LIBS_Linux  m   )
 file( GLOB_RECURSE SOURCES_C  src/*.c )
 file( GLOB_RECURSE SOURCES_XC src/*.xc )
 
-set( XSCOPE_CONFIG config.xscope )
+# set( XSCOPE_CONFIG config.xscope )
+get_filename_component(XSCOPE_CONFIG config.xscope ABSOLUTE)
 
 ## Compile flags
 unset(COMPILE_FLAGS)
@@ -32,6 +33,7 @@ list( APPEND  LINKER_FLAGS  "" )
 unset(LINKER_FLAGS_XCORE)
 list( APPEND  LINKER_FLAGS_XCORE  -target=${XCORE_TARGET} )
 list( APPEND  LINKER_FLAGS_XCORE  -report                 )
+list( APPEND  LINKER_FLAGS_XCORE  ${XSCOPE_CONFIG}        )
 
 unset(LINKER_FLAGS_Linux)
 list( APPEND  LINKER_FLAGS_Linux  ""                      )
@@ -41,7 +43,6 @@ list( APPEND  LINKER_FLAGS_Linux  ""                      )
 
 list( APPEND  SOURCES         ${SOURCES_C}     )
 list( APPEND  SOURCES_XCORE   ${SOURCES_XC}    )
-list( APPEND  SOURCES_XCORE   ${XSCOPE_CONFIG} )
 list( APPEND  SOURCES   ${SOURCES_${CMAKE_SYSTEM_NAME}} )
 
 list( APPEND  COMPILE_FLAGS ${COMPILE_FLAGS_${CMAKE_SYSTEM_NAME}} )


### PR DESCRIPTION
- Configurable support for the XS3_MATH_VECTOR_TAIL_SUPPORT option has been removed.
- Functions that previously supported it now assume the tail is to be supported.
- Any functions that do not support vector tails must explicitly declare so in their documentation.